### PR TITLE
bugfix/accurics_remediation_6627362804969912 - Auto Generated Pull Request From Accurics

### DIFF
--- a/aws/s3_bucket.tf
+++ b/aws/s3_bucket.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "tenable_cs_demo_s3_bucket" {
   bucket = "tenablecsdemos3bucket"
-  acl    = "public-read"
+  acl    = "private"
   tags   = var.default_tags
 }


### PR DESCRIPTION
The Amazon S3 Block Public Access feature provides settings for access points, buckets, and accounts to help manage public access to Amazon S3 resources. By default, new buckets, access points, and objects don't allow public access. However, users can modify bucket policies, access point policies, or object permissions to allow public access. S3 Block Public Access settings override these policies and permissions to limit public access to these resources.